### PR TITLE
Allow emitting excluded messages with a different tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ exclude some records.
       key hoge
       value 100
       regexp false # default false, string comparison
-      add_tag_prefix debug
+      add_tag_prefix debug.
     </match>  
+
+  `remove_tag_prefix`, `remove_tag_suffix` and `add_tag_suffix` options are also supported
 
 #### Assuming following inputs are coming:
     test.aa: {"json":"dayo"}
     test.aa: {"hoge":"100"}
-#### then output bocomes as belows
+#### then output becomes as belows
     debug.test.aa: {"json":"dayo"} 
 
 ### Use YmlFile exclude
@@ -28,15 +30,17 @@ exclude some records.
       type exclude_filter
       file_path path/to/test.yml 
       regexp true # default false
-      add_tag_prefix debug
+      add_tag_prefix debug.
     </match>  
 
 #### test.yml as blows
 
-  <p>hoge: 100</p>
-  <p>moge:</p>
-  <p>  - ^aaa</p>
-  <p>  - bbb</p>
+```
+hoge: 100
+moge:
+  - ^aaa
+  - bbb
+```
 
 #### Assuming following inputs are coming:
     test.aa: {"json":"dayo"}
@@ -44,12 +48,43 @@ exclude some records.
     test.aa: {"hoge":"200"}
     test.aa: {"moge":"aaa bbb"}
     test.aa: {"moge":"aaa ccc"}
+    test.aa: {"moge":"ccc bbb"}
     test.aa: {"moge":"ccc ddd"}
-#### then output bocomes as belows
-    debug.test.aa: {"json":"dayo"} 
+#### then output becomes as belows
+    debug.test.aa: {"json":"dayo"}
     debug.test.aa: {"hoge":"200"}
     debug.test.aa: {"moge":"ccc ddd"}
 
+### Forward excluded
+    <match test.**>
+      type exclude_filter
+      file_path path/to/test.yml
+      add_tag_prefix debug.
+      <excluded>
+        add_tag_prefix excl.
+      </excluded>
+    </match>
+
+  with the same test.yml file as above
+
+#### Assuming following inputs are coming:
+    test.aa: {"json":"dayo"}
+    test.aa: {"hoge":"100"}
+    test.aa: {"hoge":"200"}
+    test.aa: {"moge":"aaa bbb"}
+    test.aa: {"moge":"aaa ccc"}
+    test.aa: {"moge":"ccc bbb"}
+    test.aa: {"moge":"ccc ddd"}
+#### then output becomes as belows
+    debug.test.aa: {"json":"dayo"} 
+    excl.test.aa: {"hoge":"100"}
+    debug.test.aa: {"hoge":"200"}
+    excl.test.aa: {"moge":"aaa bbb"}
+    excl.test.aa: {"moge":"aaa ccc"}
+    excl.test.aa: {"moge":"ccc bbb"}
+    debug.test.aa: {"moge":"ccc ddd"}
+
+  routing non matching messages with tag `excl.` prepended instead of `debug.`
 
 ## Copyright
     Copyright (c) 2014 yu-yamada

--- a/lib/fluent/plugin/out_exclude_filter.rb
+++ b/lib/fluent/plugin/out_exclude_filter.rb
@@ -11,29 +11,45 @@ class Fluent::ExcludeFilterOutput < Fluent::Output
 
   def initialize
     super
+    @excluded = nil
   end
+
+  attr_reader :excluded
 
   def configure(conf)
     super
-
-    @key = @key.to_s
-    @value = @value.to_s 
 
    @excludes_yml = nil
    if @file_path
      @excludes_yml = YAML.load_file(@file_path)
    end 
+
+    store_excluded_conf = conf.elements.select {|element|
+      element.name == 'excluded'
+    }
+    case store_excluded_conf.length
+    when 0
+      @excluded = nil
+    when 1
+      e = store_excluded_conf[0]
+      @excluded = TagNameMixer.new()
+      @excluded.configure(e)
+    else
+      raise Fluent::ConfigError, "exclude_filter: <excluded> directive should be defined only once."
+    end
   end
 
   def emit(tag, es, chain)
 
     es.each do |time,record|
-      if @key && @value
-        next if match(@key, @value, record) 
+      if any_match(record)
+        if @excluded
+          emit_tag = tag.dup
+          @excluded.filter_record(emit_tag, time, record)
+          Fluent::Engine.emit(emit_tag, time, record)
+        end
+        next
       end
-      if @excludes_yml
-        next if yml_match(record)
-      end 
 
       emit_tag = tag.dup
       filter_record(emit_tag, time, record)
@@ -41,6 +57,16 @@ class Fluent::ExcludeFilterOutput < Fluent::Output
     end
 
     chain.next
+  end
+
+  def any_match(record)
+    if @key && @value
+      return true if match(@key, @value, record) 
+    end
+    if @excludes_yml
+      return true if yml_match(record)
+    end 
+    return false
   end
 
   def yml_match(record)
@@ -66,4 +92,9 @@ class Fluent::ExcludeFilterOutput < Fluent::Output
       return record[k] == v.to_s
     end
   end 
+
+  class TagNameMixer < Object
+    include Fluent::Configurable
+    include Fluent::HandleTagNameMixin
+  end
 end

--- a/test/plugin/test_out_exclude_filter.rb
+++ b/test/plugin/test_out_exclude_filter.rb
@@ -14,6 +14,14 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
     add_tag_prefix debug.
   ]
 
+  EXCLUDE_CONFIG = %[
+    <excluded>
+      add_tag_prefix excl.
+    </excluded>
+  ]
+
+  CONFIG_WITH_EXCLUDE = CONFIG + EXCLUDE_CONFIG
+
   def create_driver(conf = CONFIG)
     Fluent::Test::OutputTestDriver.new(Fluent::ExcludeFilterOutput).configure(conf)
   end
@@ -24,6 +32,21 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
     assert_equal 'debug.', d.instance.add_tag_prefix
     assert_equal 'hoge', d.instance.config['key']
     assert_equal '100', d.instance.config['value']
+    assert d.instance.excluded.nil?
+
+    d = create_driver(CONFIG_WITH_EXCLUDE)
+
+    assert_equal 'debug.', d.instance.add_tag_prefix
+    assert_equal 'hoge', d.instance.config['key']
+    assert_equal '100', d.instance.config['value']
+    assert_equal Fluent::ExcludeFilterOutput::TagNameMixer, d.instance.excluded.class
+    assert_equal 'excl.', d.instance.excluded.add_tag_prefix
+  end
+
+  def test_configure_raise
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONFIG + EXCLUDE_CONFIG * 2)
+    end
   end
 
   def test_simple
@@ -37,13 +60,29 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
     assert_equal  "debug.#{d.tag}", d.emits[0][0]
     
   end
+
+  def test_simple_with_excluded
+    d = create_driver(CONFIG_WITH_EXCLUDE)
+    emits = [
+      {"json" => "dayo"},
+      {"hoge" => "100"}  ]
+    d.run do
+      emits.each { |e|
+        d.emit(e)
+      }
+    end
+
+    assert_equal emits, d.records
+    assert_equal [ "debug.#{d.tag}", "excl.#{d.tag}" ] , d.emits.map {|tag, time, record| tag}
+  end
+
   def test_yml
     yml_path = File.dirname(__FILE__) + "/../conf/test.yml"
 
     d = create_driver %[
           file_path #{yml_path}
           regexp true
-          add_tag_prefix debug
+          add_tag_prefix debug.
         ]
 
     d.run do
@@ -56,5 +95,41 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
       d.emit("moge" => "ccc ddd")
     end
     assert_equal [ {"json"=>"dayo"}, {"hoge"=>"200"}, {"moge"=>"ccc ddd"} ], d.records 
+    d.emits.each { |tag, time, record|
+      assert_equal "debug.#{d.tag}", tag
+    }
+  end
+
+  def test_yml_with_excluded
+    yml_path = File.dirname(__FILE__) + "/../conf/test.yml"
+
+    d = create_driver (%[
+          file_path #{yml_path}
+          regexp true
+          add_tag_prefix debug.
+        ] + EXCLUDE_CONFIG)
+
+    emits = [
+      {"json" => "dayo"},
+      {"hoge" => "100"},
+      {"hoge" => "200"},
+      {"moge" => "aaa bbb"},
+      {"moge" => "aaa ccc"},
+      {"moge" => "ccc bbb"},
+      {"moge" => "ccc ddd"}  ]
+    d.run do
+      emits.each { |e|
+        d.emit(e)
+      }
+    end
+    assert_equal emits, d.records 
+    assert_equal [
+      "debug.#{d.tag}",
+      "excl.#{d.tag}",
+      "debug.#{d.tag}",
+      "excl.#{d.tag}",
+      "excl.#{d.tag}",
+      "excl.#{d.tag}",
+      "debug.#{d.tag}" ] , d.emits.map {|tag, time, record| tag}
   end
 end 

--- a/test/plugin/test_out_exclude_filter.rb
+++ b/test/plugin/test_out_exclude_filter.rb
@@ -11,7 +11,7 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
     key hoge
     value 100
     regexp false
-    add_tag_prefix debug
+    add_tag_prefix debug.
   ]
 
   def create_driver(conf = CONFIG)
@@ -21,7 +21,7 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
   def test_configure
     d = create_driver
 
-    assert_equal 'debug', d.instance.config['add_tag_prefix']
+    assert_equal 'debug.', d.instance.add_tag_prefix
     assert_equal 'hoge', d.instance.config['key']
     assert_equal '100', d.instance.config['value']
   end
@@ -34,6 +34,7 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
     end
   
     assert_equal [ {"json" => "dayo"} ], d.records 
+    assert_equal  "debug.#{d.tag}", d.emits[0][0]
     
   end
   def test_yml
@@ -51,6 +52,7 @@ class ExcludeFilterOutputTest < Test::Unit::TestCase
       d.emit("hoge" => "200")
       d.emit("moge" => "aaa bbb")
       d.emit("moge" => "aaa ccc")
+      d.emit("moge" => "ccc bbb")
       d.emit("moge" => "ccc ddd")
     end
     assert_equal [ {"json"=>"dayo"}, {"hoge"=>"200"}, {"moge"=>"ccc ddd"} ], d.records 


### PR DESCRIPTION
This allows to split the flow into 2 different outputs by switching on the flexible pattern matching given by this filter.