### PR TITLE
Adopt v0.14 compatible layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
+- 2.4.2
+- 2.3.5
 - 2.2
 - 2.1
-- 2.0.0
-- 1.9.3
 bundler_args: --jobs=2
 script: rake test
 branches:

--- a/lib/fluent/plugin/out_exclude_filter.rb
+++ b/lib/fluent/plugin/out_exclude_filter.rb
@@ -2,6 +2,11 @@ require 'yaml'
 class Fluent::ExcludeFilterOutput < Fluent::Output
   Fluent::Plugin.register_output('exclude_filter', self)
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :key, :string, :default => nil
   config_param :value, :string, :default => nil
   config_param :file_path, :string, :default => nil
@@ -43,7 +48,7 @@ class Fluent::ExcludeFilterOutput < Fluent::Output
         next if yml_match(record)
       end 
 
-      Fluent::Engine.emit(emit_tag, time, record)
+      router.emit(emit_tag, time, record)
     end
 
     chain.next


### PR DESCRIPTION
Because `Engine.emit` is treated as a bug since v0.14.

Otherwise, the following `RuntimeError` occurred:

```log
Error: test_yml(ExcludeFilterOutputTest): RuntimeError: BUG: use router.emit instead of Engine.emit
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/engine.rb:173:in `emit'
~/GitHub/fluent-plugin-exclude-filter/lib/fluent/plugin/out_exclude_filter.rb:46:in `block in emit'
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/event.rb:107:in `each'
~/GitHub/fluent-plugin-exclude-filter/lib/fluent/plugin/out_exclude_filter.rb:38:in `emit'
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/compat/output.rb:164:in `process'
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/plugin/output.rb:739:in `emit_sync'
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/test/output_test.rb:46:in `emit'
~/GitHub/fluent-plugin-exclude-filter/test/plugin/test_out_exclude_filter.rb:49:in `block in test_yml'
     46:         ]
     47: 
     48:     d.run do
  => 49:       d.emit("json" => "dayo")
     50:       d.emit("hoge" => "100")
     51:       d.emit("hoge" => "200")
     52:       d.emit("moge" => "aaa bbb")
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/test/input_test.rb:124:in `block in run'
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/test/base.rb:71:in `run'
~/GitHub/fluent-plugin-exclude-filter/vendor/bundle/ruby/2.4.0/gems/fluentd-0.14.21/lib/fluent/test/input_test.rb:123:in `run'
~/GitHub/fluent-plugin-exclude-filter/test/plugin/test_out_exclude_filter.rb:48:in `test_yml'
```